### PR TITLE
Added Description for payments

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,7 @@ export type PayPalButtonProps = {
   paypalOptions: PaypalOptions;
   buttonStyles?: ButtonStylingOptions,
   amount: number | string;
+  description?: string;
   subscriptionPlanId?: string;
   onApprove?: (data: OnApproveData, authId: string) => void;
   onPaymentStart?: () => void;

--- a/src/utils/usePaypalMethods.ts
+++ b/src/utils/usePaypalMethods.ts
@@ -27,7 +27,8 @@ export function usePaypalMethods (props: PayPalButtonProps){
         purchase_units: [{
           amount: {
             value: props.amount
-          }
+            },
+          description: props.description
         }]
       })
     }, [ props.amount ]);
@@ -97,7 +98,8 @@ export function usePaypalMethods (props: PayPalButtonProps){
           amount: {
             total: props.amount,
             currency: props.paypalOptions.currency,
-          }
+          },
+          description: props.description
         }
       ]
     })

--- a/src/utils/usePaypalScriptOptions.ts
+++ b/src/utils/usePaypalScriptOptions.ts
@@ -2,7 +2,7 @@ import { PayPalButtonProps } from '../types';
 import { usePaypalMethods } from '.';
 
 export function usePaypalScriptOptions(props: PayPalButtonProps) {
-  const { buttonStyles: style, amount } = props;
+  const { buttonStyles: style, amount, description } = props;
   const {
     createOrder, 
     createSubscription, 
@@ -16,6 +16,7 @@ export function usePaypalScriptOptions(props: PayPalButtonProps) {
   return {
     style,
     amount,
+    description,
     createOrder,
     createSubscription,
     onApprove,


### PR DESCRIPTION
This change allows you to add a basic description for the payment. The description field is optional, and everything otherwise works the same.